### PR TITLE
Remove unwrap that may failed on drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ crossbeam-channel = "0.5"
 serde = {version = "1.0", features = ["derive"], optional = true}
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["iphlpapi", "netioapi"] }
+windows = { version = "0.59.0" , features = ["Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis"]}
 
 [dev-dependencies]
 serde_json = {version = "1.0"}

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -32,7 +32,7 @@ pub(crate) trait SystemRouteOperate {
     fn new(sender: Sender<RouteEvent>) -> Self
     where
         Self: Sized;
-    fn init(&self) -> io::Result<()>;
+    fn init(&mut self) -> io::Result<()>;
     fn read_all_routes(&self) -> io::Result<Vec<Route>>;
     fn add_route(&self, route: &Route) -> io::Result<()>;
     fn delete_route(&self, route: &Route) -> io::Result<()>;
@@ -82,7 +82,7 @@ impl RouteManager {
 
         let (tx, rx) = crossbeam_channel::unbounded();
         let (tx_loop, rx_loop) = crossbeam_channel::unbounded();
-        let operator = Box::new(WindowsOperator::new(tx));
+        let mut operator = Box::new(WindowsOperator::new(tx));
         operator.init()?;
         let routes = operator.read_all_routes().unwrap();
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -245,7 +245,9 @@ extern "system" fn callback(
             n if n == MibDeleteInstance => RouteEvent::Delete(route),
             _ => return,
         };
-        sender.send(event).unwrap();
+        if let Err(_) = sender.send(event) {
+            // If there is no receiver, this may indicate that the system is currently shutting down
+        }
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -16,44 +16,39 @@
  * limitations under the License.
  */
 
-use std::{io, net::IpAddr};
+use std::{io, net::{IpAddr, Ipv4Addr, Ipv6Addr}, slice};
 
 use crossbeam_channel::Sender;
-use winapi::{
-    shared::{
-        netioapi::*,
-        nldef::MIB_IPPROTO_NETMGMT,
-        ntdef::{BOOLEAN, HANDLE, PVOID},
-        ws2def::{AF_INET, AF_INET6, AF_UNSPEC, PSOCKADDR, SOCKADDR_IN},
-        ws2ipdef::SOCKADDR_IN6,
-    },
-    um::iphlpapi::GetBestInterfaceEx,
-};
+use windows::Win32::{Foundation::HANDLE, NetworkManagement::{IpHelper::{CancelMibChangeNotify2, CreateIpForwardEntry2, DeleteIpForwardEntry2, FreeMibTable, GetBestInterfaceEx, GetIpForwardTable2, InitializeIpForwardEntry, MibAddInstance, MibDeleteInstance, MibParameterNotification, NotifyRouteChange2, MIB_IPFORWARD_ROW2, MIB_NOTIFICATION_TYPE}, Ndis::NET_LUID_LH}, Networking::WinSock::{AF_INET, AF_INET6, AF_UNSPEC, MIB_IPPROTO_NETMGMT, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6}};
 
 use crate::{manager::SystemRouteOperate, Route, RouteEvent};
 
 pub(crate) struct WindowsOperator {
     notify_handle: Option<HANDLE>,
-    sender: Sender<RouteEvent>,
+    // ensure a constant memory address for callback fn
+    sender: *mut Sender<RouteEvent>,
 }
 
 impl WindowsOperator {
-    fn register_route_listener(&self) -> io::Result<()> {
+    fn register_route_listener(&mut self) -> io::Result<()> {
         if let Some(_) = self.notify_handle {
             return Err(code_to_error(5010, "Already registered"));
         } else {
-            let mut handle = std::ptr::null_mut();
+            let mut handle = HANDLE::default();
             let ret = unsafe {
                 NotifyRouteChange2(
-                    AF_UNSPEC as u16,
+                    AF_UNSPEC,
                     Some(callback),
-                    std::mem::transmute(&self.sender),
-                    BOOLEAN::from(false),
+                    self.sender.cast(),
+                    false,
                     &mut handle,
                 )
             };
-            if ret != 0 {
-                return Err(code_to_error(ret, "error notify route change"));
+            if ret.is_err() {
+                return Err(code_to_error(ret.0, "error notify route change"));
+            }
+            if !handle.is_invalid() {
+                self.notify_handle = Some(handle)
             }
             Ok(())
         }
@@ -73,8 +68,8 @@ impl SystemRouteOperate for WindowsOperator {
         };
 
         let err = unsafe { CreateIpForwardEntry2(&row) };
-        if err != 0 {
-            return Err(code_to_error(err, "error creating entry"));
+        if err.is_err() {
+            return Err(code_to_error(err.0, "error creating entry"));
         }
         Ok(())
     }
@@ -83,37 +78,31 @@ impl SystemRouteOperate for WindowsOperator {
         let row: MIB_IPFORWARD_ROW2 = MIB_IPFORWARD_ROW2::from(route);
 
         let err = unsafe { DeleteIpForwardEntry2(&row) };
-        if err != 0 {
-            return Err(code_to_error(err, "error deleting entry"));
+        if err.is_err() {
+            return Err(code_to_error(err.0, "error deleting entry"));
         }
         Ok(())
     }
 
     fn read_all_routes(&self) -> io::Result<Vec<Route>> {
-        let mut ptable: PMIB_IPFORWARD_TABLE2 = std::ptr::null_mut();
+        let mut ptable = std::ptr::null_mut();
 
-        let ret = unsafe { GetIpForwardTable2(AF_UNSPEC as u16, &mut ptable) };
-        if ret != 0 {
-            return Err(code_to_error(ret, "Error getting table"));
+        let ret = unsafe { GetIpForwardTable2(AF_UNSPEC, &mut ptable) };
+        if ret.is_err() {
+            return Err(code_to_error(ret.0, "Error getting table"));
         }
 
-        let prows = unsafe {
-            std::ptr::slice_from_raw_parts(
-                &(*ptable).Table as *const MIB_IPFORWARD_ROW2,
-                (*ptable).NumEntries as usize,
-            )
-        };
+        let num_entries = usize::try_from(unsafe { *ptable }.NumEntries).unwrap();
 
-        let entries = unsafe { (*ptable).NumEntries };
-        let res = (0..entries)
-            .map(|idx| unsafe { (*prows)[idx as usize] })
-            .filter_map(|row| Some(Route::from(&row)))
-            .collect();
-        unsafe { FreeMibTable(ptable as *mut _) };
+        let rows = unsafe { slice::from_raw_parts((*ptable).Table.as_ptr(), num_entries) }.to_vec();
+
+        let res = rows.iter().filter_map(|row| Some(Route::from(row))).collect();
+
+        unsafe { FreeMibTable(ptable as *const _) };
         Ok(res)
     }
 
-    fn init(&self) -> io::Result<()> {
+    fn init(&mut self) -> io::Result<()> {
         self.register_route_listener()?;
         Ok(())
     }
@@ -124,7 +113,7 @@ impl SystemRouteOperate for WindowsOperator {
     {
         Self {
             notify_handle: None,
-            sender,
+            sender: Box::into_raw(Box::new(sender)),
         }
     }
 }
@@ -133,47 +122,40 @@ impl Drop for WindowsOperator {
     fn drop(&mut self) {
         if let Some(handle) = self.notify_handle {
             unsafe {
-                CancelMibChangeNotify2(handle);
+                let _ = CancelMibChangeNotify2(handle);
             }
         }
+        unsafe { drop(Box::from_raw(self.sender)) }
     }
 }
 
 impl From<&MIB_IPFORWARD_ROW2> for Route {
     fn from(row: &MIB_IPFORWARD_ROW2) -> Self {
-        let dst_family = unsafe { (*row).DestinationPrefix.Prefix.si_family() };
+        let dst_family = unsafe { row.DestinationPrefix.Prefix.si_family };
         let dst = unsafe {
-            match *dst_family as i32 {
-                AF_INET => IpAddr::from(std::mem::transmute::<_, [u8; 4]>(
-                    (*row).DestinationPrefix.Prefix.Ipv4().sin_addr,
-                )),
-                AF_INET6 => IpAddr::from(std::mem::transmute::<_, [u8; 16]>(
-                    (*row).DestinationPrefix.Prefix.Ipv6().sin6_addr,
-                )),
-                _ => panic!("Unexpected family {}", dst_family),
+            match dst_family {
+                AF_INET => IpAddr::from(Ipv4Addr::from(row.DestinationPrefix.Prefix.Ipv4.sin_addr)),
+                AF_INET6 => IpAddr::from(Ipv6Addr::from(row.DestinationPrefix.Prefix.Ipv6.sin6_addr)),
+                _ => panic!("Unexpected family {:?}", dst_family),
             }
         };
 
-        let dst_len = (*row).DestinationPrefix.PrefixLength;
+        let dst_len = row.DestinationPrefix.PrefixLength;
 
-        let nexthop_family = unsafe { (*row).NextHop.si_family() };
+        let nexthop_family = unsafe { row.NextHop.si_family };
 
         let gateway = unsafe {
-            match *nexthop_family as i32 {
-                AF_INET => IpAddr::from(std::mem::transmute::<_, [u8; 4]>(
-                    (*row).NextHop.Ipv4().sin_addr,
-                )),
-                AF_INET6 => IpAddr::from(std::mem::transmute::<_, [u8; 16]>(
-                    (*row).NextHop.Ipv6().sin6_addr,
-                )),
-                _ => panic!("Unexpected family {}", dst_family),
+            match nexthop_family {
+                AF_INET => IpAddr::from(Ipv4Addr::from(row.NextHop.Ipv4.sin_addr)),
+                AF_INET6 => IpAddr::from(Ipv6Addr::from(row.NextHop.Ipv6.sin6_addr)),
+                _ => panic!("Unexpected family {:?}", dst_family),
             }
         };
 
         let mut route = Route::new(dst, dst_len)
-            .ifindex((*row).InterfaceIndex)
-            .luid(unsafe { std::mem::transmute((*row).InterfaceLuid) })
-            .metric((*row).Metric);
+            .ifindex(row.InterfaceIndex)
+            .luid(unsafe { row.InterfaceLuid.Value })
+            .metric(row.Metric);
 
         route.gateway = gateway;
         route
@@ -182,7 +164,7 @@ impl From<&MIB_IPFORWARD_ROW2> for Route {
 
 impl From<&Route> for MIB_IPFORWARD_ROW2 {
     fn from(route: &Route) -> Self {
-        let mut row: MIB_IPFORWARD_ROW2 = unsafe { std::mem::zeroed() };
+        let mut row: MIB_IPFORWARD_ROW2 = MIB_IPFORWARD_ROW2::default();
         unsafe { InitializeIpForwardEntry(&mut row) };
 
         if let Some(ifindex) = route.ifindex {
@@ -190,31 +172,31 @@ impl From<&Route> for MIB_IPFORWARD_ROW2 {
         }
 
         if let Some(luid) = route.luid {
-            row.InterfaceLuid = unsafe { std::mem::transmute(luid) };
+            let mut api_luid = NET_LUID_LH::default();
+            api_luid.Value = luid;
+            row.InterfaceLuid = api_luid;
         }
 
         match route.gateway {
-            IpAddr::V4(addr) => unsafe {
-                *row.NextHop.si_family_mut() = AF_INET as u16;
-                row.NextHop.Ipv4_mut().sin_addr = std::mem::transmute(addr.octets());
+            IpAddr::V4(addr) => {
+                row.NextHop.si_family = AF_INET;
+                row.NextHop.Ipv4.sin_addr = addr.into();
             },
-            IpAddr::V6(addr) => unsafe {
-                *row.NextHop.si_family_mut() = AF_INET as u16;
-                row.NextHop.Ipv6_mut().sin6_addr = std::mem::transmute(addr.octets());
+            IpAddr::V6(addr) => {
+                row.NextHop.si_family = AF_INET;
+                row.NextHop.Ipv6.sin6_addr = addr.into();
             },
         }
 
         row.DestinationPrefix.PrefixLength = route.prefix;
         match route.destination {
-            IpAddr::V4(addr) => unsafe {
-                *row.DestinationPrefix.Prefix.si_family_mut() = AF_INET as u16;
-                row.DestinationPrefix.Prefix.Ipv4_mut().sin_addr =
-                    std::mem::transmute(addr.octets());
+            IpAddr::V4(addr) => {
+                row.DestinationPrefix.Prefix.si_family = AF_INET;
+                row.DestinationPrefix.Prefix.Ipv4.sin_addr = addr.into();
             },
-            IpAddr::V6(addr) => unsafe {
-                *row.DestinationPrefix.Prefix.si_family_mut() = AF_INET6 as u16;
-                row.DestinationPrefix.Prefix.Ipv6_mut().sin6_addr =
-                    std::mem::transmute(addr.octets());
+            IpAddr::V6(addr) => {
+                row.DestinationPrefix.Prefix.si_family = AF_INET6;
+                row.DestinationPrefix.Prefix.Ipv6.sin6_addr = addr.into();
             },
         }
 
@@ -231,22 +213,22 @@ impl From<&Route> for MIB_IPFORWARD_ROW2 {
 }
 
 extern "system" fn callback(
-    callercontext: PVOID,
-    row: PMIB_IPFORWARD_ROW2,
+    callercontext: *const core::ffi::c_void,
+    row: *const MIB_IPFORWARD_ROW2,
     notification_type: MIB_NOTIFICATION_TYPE,
 ) {
     unsafe {
-        // let tx = &*(callercontext as *const broadcast::Sender<RouteChange>);
         let route = Route::from(&*row);
-        let sender: &Sender<RouteEvent> = std::mem::transmute(callercontext);
-        let event = match notification_type {
-            n if n == MibParameterNotification => RouteEvent::Change(route),
-            n if n == MibAddInstance => RouteEvent::Add(route),
-            n if n == MibDeleteInstance => RouteEvent::Delete(route),
-            _ => return,
-        };
-        if let Err(_) = sender.send(event) {
-            // If there is no receiver, this may indicate that the system is currently shutting down
+        if let Some(sender) = (callercontext as *const Sender<RouteEvent>).as_ref() {
+            let event = match notification_type {
+                n if n == MibParameterNotification => RouteEvent::Change(route),
+                n if n == MibAddInstance => RouteEvent::Add(route),
+                n if n == MibDeleteInstance => RouteEvent::Delete(route),
+                _ => return,
+            };
+            if let Err(_) = sender.send(event) {
+                // If there is no receiver, this may indicate that the system is currently shutting down
+            }
         }
     }
 }
@@ -267,22 +249,16 @@ pub fn find_best_interface(ip: IpAddr) -> io::Result<u32> {
     let mut result: u32 = 0;
     let ret = match ip {
         IpAddr::V4(v4) => {
-            let mut addr: SOCKADDR_IN = unsafe { std::mem::zeroed() };
-            addr.sin_family = AF_INET as u16;
-            addr.sin_addr = unsafe { std::mem::transmute(v4.octets()) };
-            let ptr: PSOCKADDR = unsafe { std::mem::transmute(&mut addr) };
-            unsafe { GetBestInterfaceEx(ptr, &mut result as *mut _) }
+            let mut addr = SOCKADDR_IN::default();
+            addr.sin_family = AF_INET;
+            addr.sin_addr = v4.into();
+            unsafe { GetBestInterfaceEx(&addr as *const SOCKADDR_IN as *const SOCKADDR, &mut result as *mut _) }
         }
         IpAddr::V6(v6) => {
-            let mut addr: SOCKADDR_IN6 = unsafe { std::mem::zeroed() };
-            addr.sin6_family = AF_INET6 as u16;
-            addr.sin6_addr = unsafe { std::mem::transmute(v6.octets()) };
-            let ptr: PSOCKADDR = unsafe { std::mem::transmute(&addr) };
-            let rp = result as *mut u32;
-            unsafe {
-                (*rp) = 100;
-            }
-            unsafe { GetBestInterfaceEx(ptr, result as *mut _) }
+            let mut addr: SOCKADDR_IN6 = SOCKADDR_IN6::default();
+            addr.sin6_family = AF_INET6;
+            addr.sin6_addr = v6.into();
+            unsafe { GetBestInterfaceEx(&addr as *const SOCKADDR_IN6 as *const SOCKADDR, result as *mut _) }
         }
     };
 
@@ -295,7 +271,8 @@ pub fn find_best_interface(ip: IpAddr) -> io::Result<u32> {
 
 #[cfg(test)]
 pub mod test_cast {
-    use winapi::shared::{netioapi::MIB_IPFORWARD_ROW2, nldef::MIB_IPPROTO_NETMGMT};
+
+    use windows::Win32::{NetworkManagement::IpHelper::MIB_IPFORWARD_ROW2, Networking::WinSock::MIB_IPPROTO_NETMGMT};
 
     use super::{find_best_interface, Route};
 


### PR DESCRIPTION
Hi,

This PR aim to remove an unwrap that is triggered when the system is shutting down. 

Their a race that may occur if the system is shutting down, when the `WindowsOperator` callback receive route update but the manager is dropped.